### PR TITLE
Added filter by list and pan to selected configuration options

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -969,9 +969,9 @@ function buildPopup(feature, geometry, baseLayerClick)
 			if (!(website.indexOf("http") >= 0)) {
 				website = "http://"+website;
 			}
-			$(contentDiv).append($('<div class="address"><a href="'+website+'" target="_blank">Website</a></div>').css("padding-top", 10));
+			$(contentDiv).append($('<div class="address"><a href="'+website+'" target="_blank">Launch</a></div>').css("padding-top", 10));
 			if(baseLayerClick && mobile)
-				$('#mobileSupportedLayersView').append($('<div class="mobileFeatureAddress"><a href="'+website+'" target="_blank">Website</a></div>').css("padding-top", 10));
+			    $('#mobileSupportedLayersView').append($('<div class="mobileFeatureAddress"><a href="' + website + '" target="_blank">Launch</a></div>').css("padding-top", 10));
 		}
 		
 	}
@@ -1393,7 +1393,7 @@ function shareFacebook()
 					+ '&p[images][0]=' + encodeURIComponent($("meta[property='og:image']").attr("content"));
 	
 	window.open(
-		'http://www.facebook.com/sharer.php?s=100' + options, 
+		'http://www.facebook.com/sharer/sharer.php?s=100' + options,
 		'Facebook sharing', 
 		'toolbar=0,status=0,width=626,height=436'
 	);

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> 
+﻿<!DOCTYPE html> 
 <html>
 <head>
 
@@ -78,6 +78,11 @@ var SUPPORTING_LAYERS_THAT_ARE_CLICKABLE = "";
 //
 // Location button that locates user (on supported browsers)
 var GEOLOCATOR = false;
+
+//Filter list by map extent
+var FILTER_LIST_BY_EXTENT = true;
+//Pan map when items are clicked
+var PAN_MAP_ON_ITEM_SELECT = false;
 
 /******************************************************
 ******************  end config section ****************


### PR DESCRIPTION
In index.html there are two additional configuration options:
FILTER_LIST_BY_EXTENT and PAN_MAP_ON_ITEM_SELECT. By setting
FILTER_LIST_BY_EXTENT to false, your list will never change, no matter
what you are looking at in the map. If you set PAN_MAP_ON_ITEM_SELECT to
true, the map will pan to the item when it is selected in the list.
These two options allow the short list to be controlled by the list
rather than the map. Also added query string parameters of "extent_filter" and "pan_to_item" to control these configuration options. An example is available here: http://esridotpublic.s3.amazonaws.com/Apps/shortlistwithpan/index.html. 
