### PR TITLE
Fixed class name for detail box title.

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -147,7 +147,7 @@ function init() {
     });	
 	
 	$(document).bind('cbox_complete', function(){
-		$(".details .rightDiv").height($(".details").height() - $(".details .title").height() - 40);
+		$(".details .rightDiv").height($(".details").height() - $(".details .detailsTitle").height() - 40);
 	});  
 	
 	$("#bookmarksToggle").click(function(){


### PR DESCRIPTION
JS code has incorrect class name for the detail-box title. This chops off the bottom of a long description text.

![image](https://cloud.githubusercontent.com/assets/5066828/8710254/51c4b250-2afd-11e5-96a5-bc6ac4fababa.png)
